### PR TITLE
Permit destroy on flag with shared instances

### DIFF
--- a/models.py
+++ b/models.py
@@ -353,7 +353,7 @@ class DynamicIaCValueChallenge(BaseChallenge):
 
                     msg = "Correct"
 
-                    if challenge.destroy_on_flag and sourceId != 0: # do not destroy a global instance
+                    if challenge.destroy_on_flag:
                         logger.info("destroy the instance")
                         try:
                             delete_instance(challenge.id, sourceId)
@@ -377,7 +377,7 @@ class DynamicIaCValueChallenge(BaseChallenge):
 
                     msg = "Correct"
 
-                    if challenge.destroy_on_flag and sourceId != 0:
+                    if challenge.destroy_on_flag:
                         logger.info("destroy the instance")
                         try:
                             delete_instance(challenge.id, sourceId)


### PR DESCRIPTION
By default, we had activated protection on the destruction of shared instances. But in the end, YOU are the only one to choose what you want to do... and no judgement :) 

May your usage of the plugin can unlock a new cursed technique.. https://thesavageteddy.github.io/posts/cursedctf-2024/
