### PR TITLE
chore(deps): upgrade ctfd from 3.7.4 to 3.7.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           password: ${{ secrets.docker_password }}
 
       ctfd:
-        image: ctfd/ctfd:3.7.4@sha256:b2cc1ff1767d919282cf9811ec41a9a4f994d502f502b4a8852999ffb1b7e81a
+        image: ctfd/ctfd:3.7.5@sha256:7f456b23727286c9df2b58e0b7398cc0196e2b74e4c1c5b3cda7a5b71034637d
         ports:
           - 8000:8000
         options: --mount type=bind,source=${{ github.workspace }},target=/opt/CTFd/CTFd/plugins/ctfd-chall-manager

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ jobs:
           - 6379:6379
 
       ctfd:
-        image: ctfd/ctfd:3.7.4@sha256:b2cc1ff1767d919282cf9811ec41a9a4f994d502f502b4a8852999ffb1b7e81a
+        image: ctfd/ctfd:3.7.5@sha256:7f456b23727286c9df2b58e0b7398cc0196e2b74e4c1c5b3cda7a5b71034637d
         ports:
           - 8000:8000
         options: --mount type=bind,source=${{ github.workspace }},target=/opt/CTFd/CTFd/plugins/ctfd-chall-manager

--- a/.github/workflows/redis.yaml
+++ b/.github/workflows/redis.yaml
@@ -29,7 +29,7 @@ jobs:
           - 6379:6379
 
       ctfd:
-        image: ctfd/ctfd:3.7.4@sha256:b2cc1ff1767d919282cf9811ec41a9a4f994d502f502b4a8852999ffb1b7e81a
+        image: ctfd/ctfd:3.7.5@sha256:7f456b23727286c9df2b58e0b7398cc0196e2b74e4c1c5b3cda7a5b71034637d
         ports:
           - 8000:8000
         options: --mount type=bind,source=${{ github.workspace }},target=/opt/CTFd/CTFd/plugins/ctfd-chall-manager

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This plugin allow you to use the [chall-manager](https://github.com/ctfer-io/chall-manager), to manage scenario and permit Player's to deploy their instances.
 
-Last version tested on: [3.7.4](https://github.com/CTFd/CTFd/releases/tag/3.7.4).
+Last version tested on: [3.7.5](https://github.com/CTFd/CTFd/releases/tag/3.7.5).
 
 # Features
 ## Main features for Users

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ctfd:
-    image: ctfd/ctfd:3.7.4@sha256:b2cc1ff1767d919282cf9811ec41a9a4f994d502f502b4a8852999ffb1b7e81a
+    image: ctfd/ctfd:3.7.5@sha256:7f456b23727286c9df2b58e0b7398cc0196e2b74e4c1c5b3cda7a5b71034637d
     ports:
       - 8000:8000
     networks:


### PR DESCRIPTION
This PR upgrade CTFd with latest version (3.7.5).

Tested locally