### PR TITLE
BREAKING CHANGES:  align the API with the REST standards (PUT/DELETE) + missing args in GET /api/v1/challenges 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
 
-      - name: Run Fonctional Tests in mode Teams
+      - name: Run Functional Tests in mode Teams
         run: |- 
           python -m unittest test/test_api_challenges.py
           python -m unittest test/test_api_admin_instance.py
@@ -67,7 +67,7 @@ jobs:
           admin_email: ctfer-io@protonmail.com
           admin_password: ${{ env.PASSWORD }}
 
-      - name: Run Fonctional Tests in mode Users
+      - name: Run Functional Tests in mode Users
         run: |- 
           python -m unittest test/test_api_challenges.py
           python -m unittest test/test_api_admin_instance.py

--- a/.github/workflows/redis.yaml
+++ b/.github/workflows/redis.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
 
-      - name: Run Fonctional Tests in mode Teams
+      - name: Run Functional Tests in mode Teams
         run: |- 
           python -m unittest test/test_api_challenges.py
           python -m unittest test/test_api_admin_instance.py
@@ -73,7 +73,7 @@ jobs:
           admin_email: ctfer-io@protonmail.com
           admin_password: ${{ env.PASSWORD }}
 
-      - name: Run Fonctional Tests in mode Users
+      - name: Run Functional Tests in mode Users
         run: |- 
           python -m unittest test/test_api_challenges.py
           python -m unittest test/test_api_admin_instance.py

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ To install and use the plugin, refer to the documentation at https://ctfer.io/do
 | Instances| This is a copy of Scenario for the Source that make the request                             |
 | Mana     | This is the "money" to regulate the Instance's deployment                                   |
 
+
+Shoutout to [ctfd-whale](https://github.com/frankli0324/CTFd-Whale) which helped us a lot to create this plugin

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ To install and use the plugin, refer to the documentation at https://ctfer.io/do
 | Mana     | This is the "money" to regulate the Instance's deployment                                   |
 
 
-Shoutout to [ctfd-whale](https://github.com/frankli0324/CTFd-Whale) which helped us a lot to create this plugin
+Shoutout to [ctfd-whale](https://github.com/frankli0324/CTFd-Whale) which helped us a lot to create this plugin.

--- a/api.py
+++ b/api.py
@@ -58,10 +58,8 @@ class AdminInstance(Resource):
                 'message': f"Error while communicating with CM : {e}",
             }}
 
-        return {'success': True, 'data': {
-            'message': json.loads(r.text),
-        }}
-
+        return {'success': True, 'data': json.loads(r.text)}
+    
     @staticmethod
     @admins_only
     def post():
@@ -112,16 +110,15 @@ class AdminInstance(Resource):
         finally:
             lock.admin_unlock()
 
-        return {'success': True, 'data': {
-            'message': json.loads(r.text),
-        }}
+        return {'success': True, 'data': json.loads(r.text)}
 
     @staticmethod
     @admins_only
     def patch():
         # mandatory
-        challengeId = request.args.get("challengeId")
-        sourceId = request.args.get("sourceId")
+        data = request.get_json()
+        challengeId = data.get("challengeId")
+        sourceId = data.get("sourceId")
 
         adminId = str(current_user.get_current_user().id)
         logger.info(f"Admin {adminId} request instance update for challengeId: {challengeId}, sourceId: {sourceId}")
@@ -136,16 +133,15 @@ class AdminInstance(Resource):
                 'message': f"Error while communicating with CM : {e}",
             }}
 
-        return {'success': True, 'data': {
-            'message': json.loads(r.text),
-        }}
+        return {'success': True, 'data': json.loads(r.text)}
 
     @staticmethod
     @admins_only
     def delete():
         # mandatory
-        challengeId = request.args.get("challengeId")
-        sourceId = request.args.get("sourceId")
+        data = request.get_json()
+        challengeId = data.get("challengeId")
+        sourceId = data.get("sourceId")
 
         cm_mana_total = get_config("chall-manager:chall-manager_mana_total")
 
@@ -178,9 +174,7 @@ class AdminInstance(Resource):
         finally:
             lock.admin_unlock()
 
-        return {'success': True, 'data': {
-            'message': json.loads(r.text),
-        }}
+        return {'success': True, 'data': json.loads(r.text)}
 
 
 # region UserInstance
@@ -231,9 +225,7 @@ class UserInstance(Resource):
         if 'until' in result.keys():
             data['until'] = result['until']
 
-        return {'success': True, 'data': {
-            'message': data,
-        }}
+        return {'success': True, 'data': data}
 
     @staticmethod
     @authed_only
@@ -319,16 +311,15 @@ class UserInstance(Resource):
         if 'until' in result.keys():
             data['until'] = result['until']
 
-        return {'success': True, 'data': {
-            'message': data,
-        }}
+        return {'success': True, 'data': data}
 
     @staticmethod
     @authed_only
     @challenge_visible
     def patch():
         # mandatory
-        challengeId = request.args.get("challengeId")
+        data = request.get_json()
+        challengeId = data.get("challengeId")
 
         # check userMode of CTFd
         sourceId = str(current_user.get_current_user().id)
@@ -359,9 +350,7 @@ class UserInstance(Resource):
                 'message': f"Error while communicating with CM : {e}",
             }}
 
-        return {'success': True, 'data': {
-            'message': f"{r.status_code}",
-        }}
+        return {'success': True, 'data': {}}
 
     @staticmethod
     @authed_only
@@ -370,7 +359,8 @@ class UserInstance(Resource):
         # retrieve all instances deployed by chall-manager
         cm_mana_total = get_config("chall-manager:chall-manager_mana_total")
 
-        challengeId = request.args.get("challengeId")
+        data = request.get_json()
+        challengeId = data.get("challengeId")
 
         # check userMode of CTFd
         sourceId = str(current_user.get_current_user().id)
@@ -412,9 +402,7 @@ class UserInstance(Resource):
             delete_coupon(challengeId, sourceId)
             logger.info(f"Coupon deleted for challengeId: {challengeId}, sourceId: {sourceId}")
 
-        return {'success': True, 'data': {
-            'message': json.loads(r.text),
-        }}
+        return {'success': True, 'data': {}}
 
 
 # region UserMana
@@ -442,7 +430,7 @@ class UserMana(Resource):
             lock.player_unlock()
 
         return {'success': True, 'data': {
-            'mana_used': f"{mana}",
-            'mana_total': f"{get_config('chall-manager:chall-manager_mana_total')}",
+            'used': f"{mana}",
+            'total': f"{get_config('chall-manager:chall-manager_mana_total')}",
         }}
 

--- a/assets/instances.js
+++ b/assets/instances.js
@@ -1,11 +1,16 @@
 async function delete_instance(challengeId, sourceId) {
-    let response = await CTFd.fetch("/api/v1/plugins/ctfd-chall-manager/admin/instance?challengeId=" + challengeId + "&sourceId=" + sourceId, {
+    let params = {
+        "challengeId": challengeId.toString(),
+        "sourceId": sourceId.toString()
+    };
+    let response = await CTFd.fetch("/api/v1/plugins/ctfd-chall-manager/admin/instance" , {
         method: "DELETE",
         credentials: "same-origin",
         headers: {
             "Accept": "application/json",
             "Content-Type": "application/json"
-        }
+        },
+        body: JSON.stringify(params)
     });
     console.log(response)
     response = await response.json();
@@ -13,13 +18,18 @@ async function delete_instance(challengeId, sourceId) {
 }
 
 async function renew_instance(challengeId, sourceId) {
-    let response = await CTFd.fetch("/api/v1/plugins/ctfd-chall-manager/admin/instance?challengeId=" + challengeId + "&sourceId=" + sourceId, {
+    let params = {
+        "challengeId": challengeId.toString(),
+        "sourceId": sourceId.toString()
+    };
+    let response = await CTFd.fetch("/api/v1/plugins/ctfd-chall-manager/admin/instance", {
         method: "PATCH",
         credentials: "same-origin",
         headers: {
             "Accept": "application/json",
             "Content-Type": "application/json"
-        }
+        },
+        body: JSON.stringify(params)
     });
     console.log(response)
     response = await response.json();

--- a/assets/view.js
+++ b/assets/view.js
@@ -75,18 +75,18 @@ function loadInfo() {
         $('#cm-panel-loading').hide();
         $('#cm-panel-until').hide(); 
        
-        if (response.message.connectionInfo && response.message.until) { // if instance has an until 
+        if (response.connectionInfo && response.until) { // if instance has an until 
            
             // check instance is not expired
             var now = new Date();
-            var until = new Date(response.message.until)
+            var until = new Date(response.until)
             console.log(until)
             var count_down = until - now
             if (count_down > 0) {   // if the instance is not expired         
                 
                 $('#whale-panel-stopped').hide();
                 $('#whale-panel-started').show();
-                $('#whale-challenge-lan-domain').html(response.message.connectionInfo);                
+                $('#whale-challenge-lan-domain').html(response.connectionInfo);                
                 $('#whale-challenge-count-down').text(formatCountDown(count_down)); 
                 $('#cm-panel-until').show();
                 
@@ -105,10 +105,10 @@ function loadInfo() {
                 $('#whale-challenge-lan-domain').html(''); 
             }
                     
-        } else if (response.message.connectionInfo) {    // if instance has no until         
+        } else if (response.connectionInfo) {    // if instance has no until         
             $('#whale-panel-stopped').hide();
             $('#whale-panel-started').show();
-            $('#whale-challenge-lan-domain').html(response.message.connectionInfo);
+            $('#whale-challenge-lan-domain').html(response.connectionInfo);
         } else { // if instance is expired
             $('#whale-panel-started').hide(); // hide the panel instance is up       
             $('#whale-panel-stopped').show(); // show the panel instance is down     
@@ -158,12 +158,15 @@ function loadInfo() {
 CTFd._internal.challenge.destroy = function() {
     return new Promise((resolve, reject) => {
         var challenge_id = CTFd._internal.challenge.data.id;
-        var url = "/api/v1/plugins/ctfd-chall-manager/instance?challengeId=" + challenge_id;
+        var url = "/api/v1/plugins/ctfd-chall-manager/instance"
 
         $('#whale-button-destroy').text("Waiting...");
         $('#whale-button-destroy').prop('disabled', true);
 
-        var params = {};
+        let params = {
+            "challengeId": challenge_id,
+        };
+    
 
         CTFd.fetch(url, {
             method: 'DELETE',
@@ -205,12 +208,14 @@ CTFd._internal.challenge.destroy = function() {
 
 CTFd._internal.challenge.renew = function () {
     var challenge_id = CTFd._internal.challenge.data.id;
-    var url = "/api/v1/plugins/ctfd-chall-manager/instance?challengeId=" + challenge_id;
+    var url = "/api/v1/plugins/ctfd-chall-manager/instance";
 
     $('#whale-button-renew').text("Waiting...");
     $('#whale-button-renew').prop('disabled', true);
 
-    var params = {};
+    var params = {
+        "challengeId": challenge_id,
+    };
 
     CTFd.fetch(url, {
         method: 'PATCH',

--- a/assets/view.js
+++ b/assets/view.js
@@ -145,11 +145,11 @@ function loadInfo() {
         });
         return response
     }).then(function (response){
-        if (response.mana_total == 0){
+        if (response.total == 0){
             $('.cm-panel-mana-cost-div').hide();  // hide the mana cost div if mana is disabled
         }
         else {
-            let remaining = response.mana_total - response.mana_used
+            let remaining = response.total - response.used
             $('#cm-challenge-mana-remaining').html(remaining);
         }
     });

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       LOG_LEVEL: DEBUG
       PLUGIN_SETTINGS_CM_API_URL: http://chall-manager:8080/api/v1
       PLUGIN_SETTINGS_CM_MANA_TOTAL: 10
-      REDIS_URL: redis://redis-svc:6379
-      DATABASE_URL : mysql+pymysql://root:password@mariadb-svc:3306/ctfd
+      # REDIS_URL: redis://redis-svc:6379
+      # DATABASE_URL : mysql+pymysql://root:password@mariadb-svc:3306/ctfd
     depends_on:
       - chall-manager
       # - redis-svc

--- a/models.py
+++ b/models.py
@@ -391,9 +391,3 @@ class DynamicIaCValueChallenge(DynamicValueChallenge):
                 return False, str(e)
         logger.info(f"invalid submission for CTFd flag: challenge {challenge.id} source {sourceId}")
         return False, "Incorrect"
-
-    # remove this ?
-    @classmethod
-    def solve(cls, user, team, challenge, request):
-        super().solve(user, team, challenge, request)
-        super().calculate_value(challenge)

--- a/models.py
+++ b/models.py
@@ -49,7 +49,7 @@ class DynamicIaCChallenge(DynamicChallenge):
 
 
 
-class DynamicIaCValueChallenge(BaseChallenge):
+class DynamicIaCValueChallenge(DynamicValueChallenge):
     id = "dynamic_iac"  # Unique identifier used to register challenges
     name = "dynamic_iac"  # Name of a challenge type
     templates = {  # Handlebars templates used for each aspect of challenge editing & viewing
@@ -214,7 +214,7 @@ class DynamicIaCValueChallenge(BaseChallenge):
         # Workaround
         if "state" in data.keys() and len(data.keys()) == 1:
             setattr(challenge, "state", data["state"])
-            return DynamicValueChallenge.calculate_value(challenge)
+            return super().calculate_value(challenge)
 
         # Patch Challenge on CTFd
         optional = {}
@@ -267,7 +267,7 @@ class DynamicIaCValueChallenge(BaseChallenge):
         except Exception as e:
             logger.error(f"Error while patching the challenge: {e}")
 
-        return DynamicValueChallenge.calculate_value(challenge)
+        return super().calculate_value(challenge)
 
     @classmethod
     def delete(cls, challenge):
@@ -392,8 +392,8 @@ class DynamicIaCValueChallenge(BaseChallenge):
         logger.info(f"invalid submission for CTFd flag: challenge {challenge.id} source {sourceId}")
         return False, "Incorrect"
 
+    # remove this ?
     @classmethod
     def solve(cls, user, team, challenge, request):
         super().solve(user, team, challenge, request)
-
-        DynamicValueChallenge.calculate_value(challenge)
+        super().calculate_value(challenge)

--- a/test/test_api_admin_instance.py
+++ b/test/test_api_admin_instance.py
@@ -36,13 +36,13 @@ class Test_F_AdminInstance(unittest.TestCase):
         r = requests.get(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
-        self.assertEqual("connectionInfo" in a["data"]["message"].keys(), True)
+        self.assertEqual("connectionInfo" in a["data"].keys(), True)
 
-        r = requests.patch(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        r = requests.patch(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
 
-        r = requests.delete(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        r = requests.delete(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
 
@@ -64,11 +64,11 @@ class Test_F_AdminInstance(unittest.TestCase):
         a = json.loads(r.text)
         self.assertEqual(a["success"], False)
 
-        r = requests.patch(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        r = requests.patch(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], False)
 
-        r = requests.delete(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        r = requests.delete(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], False)
 
@@ -88,11 +88,11 @@ class Test_F_AdminInstance(unittest.TestCase):
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
 
-        r = requests.patch(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        r = requests.patch(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
 
-        r = requests.delete(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        r = requests.delete(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
         
@@ -101,7 +101,12 @@ class Test_F_AdminInstance(unittest.TestCase):
     def test_delete_valid_challenge_but_no_instance(self):
         challengeId = create_challenge()
         sourceId = 999999
-        r = requests.delete(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        payload = {
+            "challengeId": f"{challengeId}",
+            "sourceId": f"{sourceId}"
+        }
+
+        r = requests.delete(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], False)
         delete_challenge(challengeId)
@@ -109,7 +114,12 @@ class Test_F_AdminInstance(unittest.TestCase):
     def test_patch_valid_challenge_but_no_instance(self):
         challengeId = create_challenge(timeout=9999)
         sourceId = 999999
-        r = requests.patch(f"{config.plugin_url}/admin/instance?challengeId={challengeId}&sourceId={sourceId}",  headers=config.headers_admin)
+        payload = {
+            "challengeId": f"{challengeId}",
+            "sourceId": f"{sourceId}"
+        }
+
+        r = requests.patch(f"{config.plugin_url}/admin/instance",  headers=config.headers_admin, data=json.dumps(payload))
         a = json.loads(r.text)
         self.assertEqual(a["success"], False)
 

--- a/test/test_api_challenges.py
+++ b/test/test_api_challenges.py
@@ -134,7 +134,7 @@ class Test_F_Challenges(unittest.TestCase):
 
         payload = {
             "challenge_id": chall_id,
-            "submission": a["data"]["message"]["flag"]
+            "submission": a["data"]["flag"]
         }
 
         r = requests.post(f"{config.ctfd_url}/api/v1/challenges/attempt", headers=config.headers_user,  data=json.dumps(payload))

--- a/test/test_api_instance.py
+++ b/test/test_api_instance.py
@@ -16,12 +16,12 @@ class Test_F_UserInstance(unittest.TestCase):
         r = post_instance(chall_id)
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)        
-        self.assertEqual("connectionInfo" in a["data"]["message"].keys(), True)
+        self.assertEqual("connectionInfo" in a["data"].keys(), True)
 
         r = get_instance(chall_id)
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
-        self.assertEqual("connectionInfo" in a["data"]["message"].keys(), True)
+        self.assertEqual("connectionInfo" in a["data"].keys(), True)
 
         r = patch_instance(chall_id)
         a = json.loads(r.text)
@@ -83,7 +83,7 @@ class Test_F_UserInstance(unittest.TestCase):
         r = post_instance(chall_id)
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)        
-        self.assertEqual("connectionInfo" in a["data"]["message"].keys(), True)
+        self.assertEqual("connectionInfo" in a["data"].keys(), True)
 
         r = post_instance(chall_id)
         a = json.loads(r.text)

--- a/test/test_api_mana.py
+++ b/test/test_api_mana.py
@@ -25,7 +25,7 @@ class Test_F_UserMana(unittest.TestCase):
 
         r = requests.get(f"{config.plugin_url}/mana",  headers=config.headers_user)
         a = json.loads(r.text)
-        self.assertEqual(a["data"]["mana_used"], str(mana_cost))
+        self.assertEqual(a["data"]["used"], str(mana_cost))
 
         r = delete_instance(chall_id)
         a = json.loads(r.text)

--- a/test/utils.py
+++ b/test/utils.py
@@ -108,11 +108,17 @@ def get_admin_instance(challengeId: int, sourceId: int):
     return r
 
 def delete_instance(challengeId: int):
-    r = requests.delete(f"{config.plugin_url}/instance?challengeId={challengeId}",  headers=config.headers_user)
+    payload = {
+        "challengeId": f"{challengeId}"
+    }
+    r = requests.delete(f"{config.plugin_url}/instance",  headers=config.headers_user, data=json.dumps(payload))
     return r
 
 def patch_instance(challengeId: int): 
-    r = requests.patch(f"{config.plugin_url}/instance?challengeId={challengeId}",  headers=config.headers_user)
+    payload = {
+        "challengeId": f"{challengeId}"
+    }
+    r = requests.patch(f"{config.plugin_url}/instance",  headers=config.headers_user, data=json.dumps(payload))
     return r
 
 # Run post on thread


### PR DESCRIPTION
Fix #83 

**BREAKING CHANGES**: 
- API endpoints now return data directly in `data` dict instead of `data.message`
- `data.message` will be only used to send message to pop-up (e.g errors)
- `PUT` and `DELETE` methods now lookup data from body instead of `GET` args
- `/mana` endpoint no longer return data prefixed with `mana_`  

Cleanup codes: 
- some typo 
- fix parents class for the `read()` method 
- based on previous changes `submit()` is no longer required