### PR TITLE
chore: use latest tag on minimal compose

### DIFF
--- a/hack/docker-compose-minimal.yml
+++ b/hack/docker-compose-minimal.yml
@@ -1,6 +1,6 @@
 services:
   ctfd:
-    image: ctferio/ctfd:3.7.7-0.4.0
+    image: ctferio/ctfd:latest
     ports:
       - 8000:8000
     environment:


### PR DESCRIPTION
This PR to use the latest tag on docker-compose-mininal instead of mark the plugin version on each release.
After this PR, we can publish the v0.5.0 tag of the plugin