### PR TITLE
Reflect CTFd version 3.8.0 and params logic for challenge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
             -e PLUGIN_SETTINGS_CM_EXPERIMENTAL_RWLOCK=true \
             -e PLUGIN_SETTINGS_CM_MANA_TOTAL=10 \
             -v ${{ github.workspace }}:/opt/CTFd/CTFd/plugins/ctfd_chall_manager \
-            ctfd/ctfd:3.7.7@sha256:9847758cdafc5ab86bdc121353dcf5a27a29ce313587270ee90a71bfbda2b910
+            ctfd/ctfd:3.8.0@sha256:61712c4af6e9cddccfafc4503484c8091f6325be286d407595b922dc9552b5ae
 
       - name: Setup basic testing env
         uses: ./.github/workflows/setup-testing

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,7 @@ jobs:
             -e PLUGIN_SETTINGS_CM_API_URL=http://chall-manager:8080 \
             -e PLUGIN_SETTINGS_CM_MANA_TOTAL=15 \
             -v ${{ github.workspace }}:/opt/CTFd/CTFd/plugins/ctfd_chall_manager \
-            ctfd/ctfd:3.7.7@sha256:9847758cdafc5ab86bdc121353dcf5a27a29ce313587270ee90a71bfbda2b910      
+            ctfd/ctfd:3.8.0@sha256:61712c4af6e9cddccfafc4503484c8091f6325be286d407595b922dc9552b5ae
 
       - name: Setup basic testing env
         uses: ./.github/workflows/setup-testing

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with: 
         repository: CTFd/CTFd
-        ref: ce098c38ffc10e881a8ce6f5361b7c54d52c369d # 3.7.7
+        ref: 5d017f72fac42eb05948f46a8dddd06a04f5c050 # 3.8.0
 
     - name: Checkout CTFd-chall-manager
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/redis.yaml
+++ b/.github/workflows/redis.yaml
@@ -60,7 +60,7 @@ jobs:
             -e WORKERS=2 \
             -e SECRET_KEY=ctfer \
             -v ${{ github.workspace }}:/opt/CTFd/CTFd/plugins/ctfd_chall_manager \
-            ctfd/ctfd:3.7.7@sha256:9847758cdafc5ab86bdc121353dcf5a27a29ce313587270ee90a71bfbda2b910      
+            ctfd/ctfd:3.8.0@sha256:61712c4af6e9cddccfafc4503484c8091f6325be286d407595b922dc9552b5ae
 
       - name: Setup basic testing env
         uses: ./.github/workflows/setup-testing

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 This plugin allow you to use the [chall-manager](https://github.com/ctfer-io/chall-manager), to manage scenario and permit Player's to deploy their instances.
 
-Last version of CTFd tested on: [3.7.7](https://github.com/CTFd/CTFd/releases/tag/3.7.7).
+Last version of CTFd tested on: [3.8.0](https://github.com/CTFd/CTFd/releases/tag/3.8.0).
 
 Last version of Chall-Manager tested on: [v0.5.0](https://github.com/ctfer-io/chall-manager/releases/tag/v0.5.0).
 

--- a/api.py
+++ b/api.py
@@ -778,13 +778,15 @@ class UserMana(Resource):
                 },
             }, 200
 
-        source_id = str(current_user.get_current_user().id)
+        user_id = int(current_user.get_current_user().id)
+        source_id = user_id
         if is_teams_mode():
-            source_id = current_user.get_current_user().team_id
+            source_id = int(current_user.get_current_user().team_id)
             # If user has no team
             if not source_id:
                 logger.info(
-                    "user {current_user.get_current_user().id} has no team, abort"
+                    "user %s has no team, abort",
+                    user_id,
                 )
                 return {"success": False, "data": {"message": "unauthorized"}}, 403
 

--- a/cypress/e2e/users.cy.js
+++ b/cypress/e2e/users.cy.js
@@ -269,7 +269,7 @@ describe("Permform tests for CTFd in the User Land", () => {
         cy.get('input[placeholder="Flag"]').type("cypress-destroy-on-flag", { parseSpecialCharSequences: false });
         cy.get('button').contains('Submit').click();
 
-        cy.get('[x-text="response.data.message"]').should('be.visible').contains("Correct, your instance has been destroyed");
+        cy.get('[x-text="response.data.message"]').should('be.visible').contains("Correct");
 
         cy.log_and_go_to_chall("user3", "user3", "cypress-destroy-on-flag");
         cy.get('[data-test-id="cm-connectionInfo-id"]').should("not.be.visible");

--- a/hack/docker-compose-redis.yml
+++ b/hack/docker-compose-redis.yml
@@ -13,7 +13,7 @@ services:
     networks:
       - testing
   ctfd-ui-1:
-    image: ctfd/ctfd:3.7.7@sha256:9847758cdafc5ab86bdc121353dcf5a27a29ce313587270ee90a71bfbda2b910
+    image: ctfd/ctfd:3.8.0@sha256:61712c4af6e9cddccfafc4503484c8091f6325be286d407595b922dc9552b5ae
     container_name: ctfd-ui-1
     networks:
       - testing
@@ -47,7 +47,7 @@ services:
       - "traefik.http.services.web.loadbalancer.server.port=8000"
     
   ctfd-ui-2:
-    image: ctfd/ctfd:3.7.7@sha256:9847758cdafc5ab86bdc121353dcf5a27a29ce313587270ee90a71bfbda2b910
+    image: ctfd/ctfd:3.8.0@sha256:61712c4af6e9cddccfafc4503484c8091f6325be286d407595b922dc9552b5ae
     container_name: ctfd-ui-2
     networks:
       - testing
@@ -88,6 +88,7 @@ services:
     environment:
       SWAGGER: true
       KUBECONFIG: /tmp/config
+      OCI_INSECURE: true
     volumes:
       - ~/.kube/config:/tmp/config:ro
     networks:
@@ -153,6 +154,13 @@ services:
     container_name: registry
     ports:
       - 5000:5000
+    networks:
+      - testing
+
+  adminer:
+    image: adminer:latest
+    ports:
+      - 8082:8080
     networks:
       - testing
 

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ctfd:
-    image: ctfd/ctfd:3.7.7@sha256:9847758cdafc5ab86bdc121353dcf5a27a29ce313587270ee90a71bfbda2b910
+    image: ctfd/ctfd:3.8.0@sha256:61712c4af6e9cddccfafc4503484c8091f6325be286d407595b922dc9552b5ae
     container_name: ctfd
     ports:
       - 8000:8000

--- a/models.py
+++ b/models.py
@@ -533,7 +533,8 @@ class DynamicIaCValueChallenge(DynamicValueChallenge):
             )
             flags.append(ctfd_cm_flag)
 
-        # CTFd behavior https://github.com/CTFd/CTFd/blob/3.8.0/CTFd/plugins/challenges/__init__.py#L131
+        # CTFd behavior
+        # https://github.com/CTFd/CTFd/blob/3.8.0/CTFd/plugins/challenges/__init__.py#L131
         if challenge.logic == "all":
             return challenge_attempt_all(submission, challenge, flags)
         if challenge.logic == "team":

--- a/models.py
+++ b/models.py
@@ -507,15 +507,12 @@ class DynamicIaCValueChallenge(DynamicValueChallenge):
                 challenge.id,
                 source_id,
             )
-            # return False, "Expired (the instance must be running to submit)"
             return ChallengeResponse(
                 status="incorrect",
                 message="Expired (the instance must be running to submit)",
             )
 
         flags = Flags.query.filter_by(challenge_id=challenge.id).all()
-        print(f"before CM: {flags}")  # TODO remove
-
         logger.debug("check if flag is provided by CM")
         if "flag" in data.keys():
             cm_flag = data["flag"]

--- a/test/test_api_challenges.py
+++ b/test/test_api_challenges.py
@@ -328,6 +328,12 @@ class Test_F_Challenges(unittest.TestCase):
         chall_id = create_challenge(logic="team")
         post_instance(chall_id)
 
+        r = requests.get(
+            f"{config.ctfd_url}/api/v1/configs/user_mode", headers=config.headers_admin
+        )
+        a = json.loads(r.text)
+        user_mode = a["data"]["value"]
+
         # provide the second flag provided by Chall-Manager
         r = get_admin_instance(chall_id, get_source_id())
         a = json.loads(r.text)
@@ -339,7 +345,12 @@ class Test_F_Challenges(unittest.TestCase):
         )
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
-        self.assertEqual(a["data"]["status"], "partial")
+
+        # if partial is returned, then logic=mode is enabled
+        if user_mode == "teams":
+            self.assertEqual(a["data"]["status"], "partial")
+        else:
+            self.assertEqual(a["data"]["status"], "correct")
 
         # clear
         reset_all_submissions()

--- a/test/test_api_challenges.py
+++ b/test/test_api_challenges.py
@@ -244,9 +244,11 @@ class Test_F_Challenges(unittest.TestCase):
 
     def test_attempt_logic_any(self):
         """
-        Check that the plugin can be use the logic=any feature.
+        Check that the plugin can be used with the logic=any feature.
         """
         chall_id = create_challenge(logic="any")
+        post_instance(chall_id)
+
         # i can flag with variate flag
         r = get_admin_instance(chall_id, get_source_id())
         a = json.loads(r.text)
@@ -269,9 +271,10 @@ class Test_F_Challenges(unittest.TestCase):
 
     def test_attempt_logic_all(self):
         """
-        Check that the plugin can be use the logic=all feature.
+        Check that the plugin can be used with the logic=all feature.
         """
         chall_id = create_challenge(logic="all")
+        post_instance(chall_id)
 
         # create ctfd flag
         ctfd_flag = "fallback"
@@ -320,9 +323,10 @@ class Test_F_Challenges(unittest.TestCase):
 
     def test_attempt_logic_team(self):
         """
-        Check that the plugin can be use the logic=team feature.
+        Check that the plugin can be used with the logic=team feature.
         """
         chall_id = create_challenge(logic="team")
+        post_instance(chall_id)
 
         # provide the second flag provided by Chall-Manager
         r = get_admin_instance(chall_id, get_source_id())
@@ -330,13 +334,12 @@ class Test_F_Challenges(unittest.TestCase):
         payload = {"challenge_id": chall_id, "submission": a["data"]["flag"]}
         r = requests.post(
             f"{config.ctfd_url}/api/v1/challenges/attempt",
-            headers=config.headers_admin,  # admin account is alone in his team
+            headers=config.headers_user,
             data=json.dumps(payload),
         )
         a = json.loads(r.text)
         self.assertEqual(a["success"], True)
-
-        self.assertEqual(a["data"]["status"], "correct")
+        self.assertEqual(a["data"]["status"], "partial")
 
         # clear
         reset_all_submissions()

--- a/test/utils.py
+++ b/test/utils.py
@@ -59,6 +59,7 @@ def create_challenge(
     additional={},
     pooler_min=None,
     pooler_max=None,
+    logic=None,
     state="visible",
 ):
     """
@@ -96,6 +97,10 @@ def create_challenge(
     if until:
         payload["until"] = until
 
+    # CTFd 3.8.0 new feature
+    if logic in ["any", "all", "team"]:
+        payload["logic"] = logic
+
     r = requests.post(
         f"{config.ctfd_url}/api/v1/challenges",
         headers=config.headers_admin,
@@ -104,7 +109,7 @@ def create_challenge(
     a = json.loads(r.text)
     if a["success"] is not True:
         raise ValueError(
-            "error while setting up the testing environment, do not process"
+            f"error while setting up the testing environment, do not process: {a}"
         )
 
     # return the chall_id
@@ -122,7 +127,7 @@ def delete_challenge(challenge_id: int):
     a = json.loads(r.text)
     if a["success"] is not True:
         raise ValueError(
-            "error while setting up the testing environment, do not process"
+            f"error while setting up the testing environment, do not process: {a}"
         )
 
 

--- a/utils/mana_coupon.py
+++ b/utils/mana_coupon.py
@@ -117,7 +117,7 @@ def get_source_mana(source_id: int) -> int:
     if result["mana"] is None:
         return 0
 
-    return result["mana"]
+    return int(result["mana"])
 
 
 def get_all_mana() -> list:

--- a/webdocs/learn-more/flag/_index.md
+++ b/webdocs/learn-more/flag/_index.md
@@ -25,32 +25,25 @@ Here's the algorithm:
 
 ```mermaid
 flowchart LR
-    Submission --> A{Instance On ?}
-    A -->|True| B{Instance I flag ?}
-    A -->|False| Expired
-    B -->|True| C{submission == I.flag}
-    B -->|False| D{CTFd C flag ?}
-    C -->|True| Correct
-    C -->|False| D
-    D -->|True| E{submission == C.flag}
-    D -->|False| Incorrect
-    E -->|True| Correct
-    E -->|False| Incorrect
-
-    %% I/O
-    Submission
-    Expired
-    Correct
-    Incorrect
+    A[Plugin Attempt] --> B{Instance ON ?}
+    B --> |False| F[incorrect]
+    B --> |True| G[flags = CTFdFlags ]
+    G --> H{Instance define flag ?}
+    H --> |False| C
+    H --> |True| I[flags = CTFdFlags + CMFlags ]
+    
+    I --> C{Attempt}
+    C --> D[partial]
+    C --> E[correct]
+    C --> F[incorrect]
 
 ``` 
 
 On the `submit` method, we get all informations of the instance on chall-manager.
 1. We want the instance ON to prevent *FlagHoarding* and make sure the submitted flag is the one in the instance.
-2. We check if the instance define a flag (if you don't use the flag variation on the sdk).
-3. If the instance define a flag, we check if the submission is correct.
-4. If the instance does not define a flag or if the submission is incorrect, we check if a flag is defined on CTFd (also use as fallback).
-5. Now, it is the classic behavior of CTFd.
+2. We check if the instance define a flag (if you use the flag variation on the sdk).
+3. If the instance define a flag, we add the dynamic flag with the CTFd ones.
+4. Then, we check flags with configured logic defined on CTFd.
 
 
 ## Conclusion
@@ -69,6 +62,3 @@ There are two main reasons for this requirement:
 
 ### Why the CTFd Flag is consider as "fallback" ?
 As we said before, the CTFd Flag system allows users to submit the same flag. We use this system to prevent connection error or latency with chall-manager or if the generated flag is invalid for synthax error (we choose the extended ASCII so it should not happen).
-
-
-

--- a/webdocs/learn-more/mana/_index.md
+++ b/webdocs/learn-more/mana/_index.md
@@ -36,7 +36,7 @@ Example:
 
 **This system helps administrators control the use of resources on CTF infrastructures.**
 
-Combined with the [flag variation engine](/docs/chall-manager/challmaker-guides/flag-variation-engine/) feature of chall-manager, mana also helps minimize *Flag Holding*. To progress, players must submit flags and destroy instances to reclaim mana. If players choose to hoard flags until the last moment, mana limits their ability to continue, adding a strategic element to the competition.
+Combined with the [flag variation engine](/docs/chall-manager/challmaker-guides/flag-variation-engine/) feature of chall-manager, mana also helps minimize *Flag Hoarding*. To progress, players must submit flags and destroy instances to reclaim mana. If players choose to hoard flags until the last moment, mana limits their ability to continue, adding a strategic element to the competition.
 
 ## How it works
 


### PR DESCRIPTION
This PR allows us to supports CTFd 3.8.0 and the `logic` behavior in flag submission for dynanic_iac challenge type.

Summary of changes: 
- Refactoring the `attempt()` method to use the logic.
- Add `solve()` method for the destroy_on_flag supports
- Update docs for the changes
- Add tests cases with all logics tested.
- Fix the KeyError introduces with [this PR](https://github.com/ctfer-io/ctfd-chall-manager/pull/181) on GET /mana

After this PR, let's make a tag `v0.6.1` (or `v0.7.0` ? ) and redeploy webdoc.

