### PR TITLE
fix: CM_API_TIMEOUT not used

### DIFF
--- a/api.py
+++ b/api.py
@@ -791,7 +791,7 @@ class UserMana(Resource):
                 return {"success": False, "data": {"message": "unauthorized"}}, 403
 
         try:
-            lock = load_or_store(f"{source_id}")
+            lock = load_or_store(str(source_id))
             logger.debug("get /mana acquire the player lock for %s", source_id)
             lock.player_lock()
 

--- a/utils/challenge_store.py
+++ b/utils/challenge_store.py
@@ -12,8 +12,7 @@ from CTFd.plugins.ctfd_chall_manager.utils.logger import configure_logger
 from CTFd.utils import get_config
 
 logger = configure_logger(__name__)
-CM_API_TIMEOUT = get_config("chall-manager_api_timeout")
-
+CM_API_TIMEOUT = get_config("chall-manager:chall-manager_api_timeout")
 # pylint: disable=duplicate-code
 # pylint detect duplicate-code between challenge_store and intance_manager
 # This is false positive

--- a/utils/instance_manager.py
+++ b/utils/instance_manager.py
@@ -12,7 +12,7 @@ from CTFd.plugins.ctfd_chall_manager.utils.logger import configure_logger
 from CTFd.utils import get_config
 
 logger = configure_logger(__name__)
-CM_API_TIMEOUT = get_config("chall-manager_api_timeout")
+CM_API_TIMEOUT = get_config("chall-manager:chall-manager_api_timeout")
 
 # pylint: disable=duplicate-code
 # pylint detect duplicate-code between challenge_store and intance_manager


### PR DESCRIPTION
This typo resulting in `timeout = None` even if configured with varenv.