### PR TITLE
chore: upgrade ctfd-setup to 1.7.1 and enable dependabot on reusable workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,12 @@ updates:
       interval: "weekly"
     assignees:
       - "NicoFgrx"
+
+  # Github actions for reusable
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows/setup-testing"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "NicoFgrx"
+

--- a/.github/workflows/setup-testing/action.yml
+++ b/.github/workflows/setup-testing/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Wait for CTFd server
       shell: bash
@@ -60,7 +60,7 @@ runs:
         fi
 
     - name: Setup CTFd
-      uses: ctfer-io/ctfd-setup@e11df98977827a789d3e07537790a3b64091493b # v1.6.0
+      uses: ctfer-io/ctfd-setup@c917efc8b6fdfcc97d6fa4e2c4d48ea533d3d774 # v1.7.1
       with:
         url: 'http://ctfd:8000'
         appearance_name: CTFer.io
@@ -72,7 +72,7 @@ runs:
         accounts_incorrect_submissions_per_minute: 9999
 
     - name: Setup Go
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
 
     - name: Generate token and store it for GH Actions
       shell: bash
@@ -99,7 +99,7 @@ runs:
         CTFD_URL: http://localhost:8000
 
     - name: Setup oras cli 
-      uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+      uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
     
     - name: Setup yq
       shell: bash

--- a/hack/.ctfd.yaml
+++ b/hack/.ctfd.yaml
@@ -11,4 +11,4 @@ mode: 'teams'
 
 accounts:
   team_creation: true
-  incorrect_submissions_per_minutes: 9999 # bypass ratelimit
+  incorrect_submissions_per_minute: 9999 # bypass ratelimit

--- a/hack/docker-compose-redis.yml
+++ b/hack/docker-compose-redis.yml
@@ -133,7 +133,7 @@ services:
     command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0]
 
   ctfd-setup:
-    image: ctferio/ctfd-setup:v1.6.0@sha256:b716c414170b4b17aa317910d8c12e53f2892867791c4912ff3319984a1ea975
+    image: ctferio/ctfd-setup:v1.7.1@sha256:d555410c10f66eb88a6579078d3f2c9131279e3057c21831a69feb447479b877
     container_name: ctfd-setup
     environment:
       URL: http://ctfd-ui-1:8000

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - testing
 
   ctfd-setup:
-    image: ctferio/ctfd-setup:v1.6.0@sha256:b716c414170b4b17aa317910d8c12e53f2892867791c4912ff3319984a1ea975
+    image: ctferio/ctfd-setup:v1.7.1@sha256:d555410c10f66eb88a6579078d3f2c9131279e3057c21831a69feb447479b877
     environment:
       URL: http://ctfd:8000
       FILE: /.ctfd.yaml


### PR DESCRIPTION
In addition of #187, upgrade `ctfd-setup` inside docker-compose file.
Also configure the dependabot scan on reusable workflow.