### PR TITLE
Bug Fix: Additional items table not displayed on Update form

### DIFF
--- a/assets/update.js
+++ b/assets/update.js
@@ -89,6 +89,5 @@ function applyAdditional() {
 
 
 displayCurrentUntil()
-displayCurrentScenario()
 displayCurrentAdditional()
 


### PR DESCRIPTION
**Bug Fix: Additional Items Table Missing on Update Form**

This PR fixes an issue where the additional items table was not displayed on the update form.

**Root Cause:**
The `displayCurrentAdditional()` function was not executed because the call to `displayCurrentScenario()` generate an error (missing). Since the scenario is no longer managed as a file, the `displayCurrentScenario()` function was previously removed, but its call was accidentally left in the code, causing an error and preventing the table from rendering.
