### PR TITLE
fix(chall): do not return scenario data for user

### DIFF
--- a/models.py
+++ b/models.py
@@ -175,7 +175,7 @@ class DynamicIaCValueChallenge(DynamicValueChallenge):
                 "timeout": challenge.timeout,
                 "shared": challenge.shared,
                 "destroy_on_flag": challenge.destroy_on_flag,
-                "scenario": challenge.scenario,
+                "scenario": challenge.scenario if current_user.is_admin() else "",
                 "additional": (
                     challenge.additional if current_user.is_admin() else {}
                 ),  # do not display additional for all user, can contains secrets

--- a/test/test_api_challenges.py
+++ b/test/test_api_challenges.py
@@ -174,6 +174,9 @@ class Test_F_Challenges(unittest.TestCase):
 
     # region get
     def test_user_cannot_get_sensitive_data(self):
+        """
+        Checks that user cannot get sensitive data (i.e additional or scenario)
+        """
         chall_id = create_challenge(
             additional={"test": "test"},
         )

--- a/test/test_api_challenges.py
+++ b/test/test_api_challenges.py
@@ -172,6 +172,35 @@ class Test_F_Challenges(unittest.TestCase):
         self.assertEqual(r.status_code, 500)  # CTFd return internal server error
         # https://github.com/CTFd/CTFd/issues/2674
 
+    # region get
+    def test_user_cannot_get_sensitive_data(self):
+        chall_id = create_challenge(
+            additional={"test": "test"},
+        )
+
+        # Admin access
+        r = requests.get(
+            f"{config.ctfd_url}/api/v1/challenges/{chall_id}",
+            headers=config.headers_admin,
+        )
+        a = json.loads(r.text)
+        self.assertEqual(a["success"], True)
+        self.assertEqual(a["data"]["scenario"], config.scenario)
+        self.assertEqual(a["data"]["additional"], {"test": "test"})
+
+
+        # User access
+        r = requests.get(
+            f"{config.ctfd_url}/api/v1/challenges/{chall_id}",
+            headers=config.headers_user,
+        )
+        a = json.loads(r.text)
+        self.assertEqual(a["success"], True)
+        self.assertEqual(a["data"]["scenario"], "")
+        self.assertEqual(a["data"]["additional"], {})
+
+        delete_challenge(chall_id)
+
     # region update
     def test_can_update_scenario(self):
         """

--- a/test/test_api_challenges.py
+++ b/test/test_api_challenges.py
@@ -188,7 +188,6 @@ class Test_F_Challenges(unittest.TestCase):
         self.assertEqual(a["data"]["scenario"], config.scenario)
         self.assertEqual(a["data"]["additional"], {"test": "test"})
 
-
         # User access
         r = requests.get(
             f"{config.ctfd_url}/api/v1/challenges/{chall_id}",


### PR DESCRIPTION
This PR hides the configured scenario from users.
This information can be used to extract elements from the scenario that may contain details about the deployment of flags or challenges. 