### PR TITLE
Improve API endpoint with validate_args decorator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       chall-manager: 
-        image: ctferio/chall-manager:v0.6.5@sha256:f30d8d4c0b2fee99ffd8b29b1821d014c0c2ef1b134f87f16ade4e21b3f72f16
+        image: ctferio/chall-manager:v0.6.6@sha256:34b5ca4b9e02db171cd58f148f927c0955c106427e97e4525e0376c2512c3959
         ports:
           - 8080:8080
         env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       chall-manager: 
-        image: ctferio/chall-manager:v0.6.5@sha256:f30d8d4c0b2fee99ffd8b29b1821d014c0c2ef1b134f87f16ade4e21b3f72f16
+        image: ctferio/chall-manager:v0.6.6@sha256:34b5ca4b9e02db171cd58f148f927c0955c106427e97e4525e0376c2512c3959
         ports:
           - 8080:8080
         env:

--- a/.github/workflows/redis.yaml
+++ b/.github/workflows/redis.yaml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       chall-manager: 
-        image: ctferio/chall-manager:v0.6.5@sha256:f30d8d4c0b2fee99ffd8b29b1821d014c0c2ef1b134f87f16ade4e21b3f72f16
+        image: ctferio/chall-manager:v0.6.6@sha256:34b5ca4b9e02db171cd58f148f927c0955c106427e97e4525e0376c2512c3959
         ports:
           - 8080:8080
         env:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin allow you to use the [chall-manager](https://github.com/ctfer-io/cha
 
 Last version of CTFd tested on: [3.8.5](https://github.com/CTFd/CTFd/releases/tag/3.8.5).
 
-Last version of Chall-Manager tested on: [v0.6.5](https://github.com/ctfer-io/chall-manager/releases/tag/v0.6.5).
+Last version of Chall-Manager tested on: [v0.6.6](https://github.com/ctfer-io/chall-manager/releases/tag/v0.6.6).
 
 ## 🚀 What CTFd-chall-manager Does
 - **On-Demand Instances**: Players can deploy and destroy their own isolated challenge instances.

--- a/api/admin/imports.py
+++ b/api/admin/imports.py
@@ -3,6 +3,7 @@ This module describes the AdminImport API endpoints of the plugin:
 Route: /api/v1/plugins/ctfd-chall-manager/admin/import.
 """
 
+from CTFd.api.v1.helpers.request import validate_args
 from CTFd.plugins.ctfd_chall_manager.models import (
     DynamicIaCChallenge,
     prepare_chall_manager_payload,
@@ -33,12 +34,17 @@ class AdminImport(Resource):
 
     @staticmethod
     @admins_only
-    def post():
+    @validate_args(
+        {
+            "challengeId": (int)
+        },
+        location="json"
+    )
+    def post(json_args):
         """
         Trigger an import
         """
-        data = request.get_json()
-        challenge_id = data.get("challengeId")
+        challenge_id = json_args.pop("challengeId", None)
         logger.info("trying to import challenge %d", challenge_id)
 
         if not challenge_id:

--- a/api/admin/imports.py
+++ b/api/admin/imports.py
@@ -34,7 +34,7 @@ class AdminImport(Resource):
 
     @staticmethod
     @admins_only
-    @validate_args({"challengeId": (int)}, location="json")
+    @validate_args({"challengeId": (int, None)}, location="json")
     def post(json_args):
         """
         Trigger an import
@@ -42,7 +42,7 @@ class AdminImport(Resource):
         challenge_id = json_args.pop("challengeId", None)
         logger.info("trying to import challenge %d", challenge_id)
 
-        if not challenge_id:
+        if challenge_id is None:
             abort(400, "missing argument challenge_id", success=False)
 
         # retrieve challenge information on CTFd

--- a/api/admin/imports.py
+++ b/api/admin/imports.py
@@ -34,12 +34,7 @@ class AdminImport(Resource):
 
     @staticmethod
     @admins_only
-    @validate_args(
-        {
-            "challengeId": (int)
-        },
-        location="json"
-    )
+    @validate_args({"challengeId": (int)}, location="json")
     def post(json_args):
         """
         Trigger an import

--- a/api/admin/instance.py
+++ b/api/admin/instance.py
@@ -7,7 +7,6 @@ from CTFd.api.v1.helpers.request import validate_args
 from CTFd.plugins.ctfd_chall_manager.utils.chall_manager_error import (
     ChallManagerException,
 )
-from CTFd.plugins.ctfd_chall_manager.utils.helpers import retrieve_all_ids
 from CTFd.plugins.ctfd_chall_manager.utils.instance_manager import (
     create_instance,
     delete_instance,
@@ -40,7 +39,7 @@ class AdminInstance(Resource):
             "sourceId": (int, None),
             "challengeId": (int, None),
         },
-        location="query"
+        location="query",
     )
     def get(query_args):
         """

--- a/api/admin/instance.py
+++ b/api/admin/instance.py
@@ -3,6 +3,7 @@ This module describes the AdminInstance API endpoints of the plugin:
 Route: /api/v1/plugins/ctfd-chall-manager/admin/instance.
 """
 
+from CTFd.api.v1.helpers.request import validate_args
 from CTFd.plugins.ctfd_chall_manager.utils.chall_manager_error import (
     ChallManagerException,
 )
@@ -15,6 +16,7 @@ from CTFd.plugins.ctfd_chall_manager.utils.instance_manager import (
 )
 from CTFd.plugins.ctfd_chall_manager.utils.lock import load_or_store
 from CTFd.plugins.ctfd_chall_manager.utils.logger import configure_logger
+from CTFd.utils import user as current_user
 from CTFd.utils.decorators import admins_only
 from flask_restx import Resource, abort
 
@@ -33,34 +35,28 @@ class AdminInstance(Resource):
 
     @staticmethod
     @admins_only
-    def get():
+    @validate_args(
+        {
+            "sourceId": (int, None),
+            "challengeId": (int, None),
+        },
+        location="query"
+    )
+    def get(query_args):
         """
         Retrieve instance infos for the sourceId and challengeId provided.
         The returned value contains all informations given by Chall-Manager API (flag included).
         """
-        admin_id = 0
-        challenge_id = 0
-        source_id = 0
 
-        try:
-            result = retrieve_all_ids(admin=True)
-            admin_id = result["admin_id"]
-            challenge_id = result["challenge_id"]
-            source_id = result["source_id"]
-        except ValueError:
+        admin_id = current_user.get_current_user()
+        challenge_id = query_args.pop("challengeId", None)
+        source_id = query_args.pop("sourceId", None)
+
+        if None in (challenge_id, source_id):
             return {
                 "success": False,
                 "message": "missing challengeId or sourceId",
             }, 400
-
-        # admin_id and challenge_id must be updated by retrieve_all_ids()
-        # source_id can be 0 (shared)
-        if admin_id == 0 or challenge_id == 0:
-            abort(
-                500,
-                "internal server error: cannot load challenge_id or admin_id",
-                sucess=False,
-            )
 
         logger.info(
             "admin %s get instance info for challenge_id: %s, source_id: %s",
@@ -89,36 +85,26 @@ class AdminInstance(Resource):
 
     @staticmethod
     @admins_only
-    def post():
+    @validate_args(
+        {
+            "challengeId": (int, None),
+            "sourceId": (int, None),
+        },
+        location="json",
+    )
+    def post(json_args):
         """
         Create instance for the sourceId and challengeId provided.
         This function will create a coupon, but bypass mana checks and
         deploy instance in all cases.
         The returned value contains all informations given by Chall-Manager API (flag included).
         """
-        admin_id = 0
-        challenge_id = 0
-        source_id = 0
+        admin_id = current_user.get_current_user()
+        challenge_id = json_args.pop("challengeId", None)
+        source_id = json_args.pop("sourceId", None)
 
-        try:
-            result = retrieve_all_ids(admin=True)
-            admin_id = result["admin_id"]
-            challenge_id = result["challenge_id"]
-            source_id = result["source_id"]
-        except ValueError:
-            return {
-                "success": False,
-                "message": "missing challengeId or sourceId",
-            }, 400
-
-        # admin_id and challenge_id must be updated by retrieve_all_ids()
-        # source_id can be 0 (shared)
-        if admin_id == 0 or challenge_id == 0:
-            abort(
-                500,
-                "internal server error: cannot load challenge_id or admin_id",
-                sucess=False,
-            )
+        if None in (challenge_id, source_id):
+            abort(404, "missing challengeId or sourceId")
 
         logger.info(
             "admin %s request instance creation for challenge_id: %s, source_id: %s",
@@ -170,36 +156,25 @@ class AdminInstance(Resource):
 
     @staticmethod
     @admins_only
-    def patch():
+    @validate_args(
+        {
+            "challengeId": (int, None),
+            "sourceId": (int, None),
+        },
+        location="json",
+    )
+    def patch(json_args):
         """
         Renew instance for the sourceId and challengeId provided.
         The returned value contains all informations given by Chall-Manager API (flag included).
         """
 
-        # mandatory
-        admin_id = 0
-        challenge_id = 0
-        source_id = 0
+        admin_id = current_user.get_current_user()
+        challenge_id = json_args.pop("challengeId", None)
+        source_id = json_args.pop("sourceId", None)
 
-        try:
-            result = retrieve_all_ids(admin=True)
-            admin_id = result["admin_id"]
-            challenge_id = result["challenge_id"]
-            source_id = result["source_id"]
-        except ValueError:
-            return {
-                "success": False,
-                "message": "missing challengeId or sourceId",
-            }, 400
-
-        # admin_id and challenge_id must be updated by retrieve_all_ids()
-        # source_id can be 0 (shared)
-        if admin_id == 0 or challenge_id == 0:
-            abort(
-                500,
-                "internal server error: cannot load challenge_id or admin_id",
-                sucess=False,
-            )
+        if None in (challenge_id, source_id):
+            abort(404, "missing challengeId or sourceId")
 
         logger.info(
             "admin %s request instance update for challenge_id: %s, source_id: %s",
@@ -232,35 +207,24 @@ class AdminInstance(Resource):
 
     @staticmethod
     @admins_only
-    def delete():
+    @validate_args(
+        {
+            "challengeId": (int, None),
+            "sourceId": (int, None),
+        },
+        location="json",
+    )
+    def delete(json_args):
         """
         Destroy instance for the sourceId and challengeId provided.
         This function will delete the associated coupon.
         """
-        # mandatory
-        admin_id = 0
-        challenge_id = 0
-        source_id = 0
+        admin_id = current_user.get_current_user()
+        challenge_id = json_args.pop("challengeId", None)
+        source_id = json_args.pop("sourceId", None)
 
-        try:
-            result = retrieve_all_ids(admin=True)
-            admin_id = result["admin_id"]
-            challenge_id = result["challenge_id"]
-            source_id = result["source_id"]
-        except ValueError:
-            return {
-                "success": False,
-                "message": "missing challengeId or sourceId",
-            }, 400
-
-        # admin_id and challenge_id must be updated by retrieve_all_ids()
-        # source_id can be 0 (shared)
-        if admin_id == 0 or challenge_id == 0:
-            abort(
-                500,
-                "internal server error: cannot load challenge_id or admin_id",
-                success=False,
-            )
+        if None in (challenge_id, source_id):
+            abort(404, "missing challengeId or sourceId")
 
         logger.info(
             "admin %s request instance delete for challenge_id: %s, source_id: %s",

--- a/api/instance.py
+++ b/api/instance.py
@@ -25,7 +25,6 @@ from CTFd.plugins.ctfd_chall_manager.utils.logger import configure_logger
 from CTFd.utils import user as current_user
 from CTFd.utils.config import is_teams_mode
 from CTFd.utils.decorators import authed_only
-from flask import request
 from flask_restx import Resource, abort
 
 # Configure logger for this module
@@ -46,12 +45,7 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    @validate_args(
-        {
-            "challengeId": (int, None)
-        },
-        location="query"
-    )
+    @validate_args({"challengeId": (int, None)}, location="query")
     def get(query_args):
         """
         Retrieve instance informations of challengeId provided on Chall-Manager.
@@ -107,12 +101,7 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    @validate_args(
-        {
-            "challengeId": (int, None)
-        },
-        location="json"
-    )
+    @validate_args({"challengeId": (int, None)}, location="json")
     def post(json_args):  # pylint: disable=too-many-return-statements,too-many-branches
         """
         Create an instance of challengeId provided on Chall-Manager.
@@ -186,12 +175,7 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    @validate_args(
-        {
-            "challengeId": (int, None)
-        },
-        location="json"
-    )
+    @validate_args({"challengeId": (int, None)}, location="json")
     def patch(json_args):  # pylint: disable=too-many-return-statements
         """
         Renew instance on Chall-Manager.
@@ -245,12 +229,7 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    @validate_args(
-        {
-            "challengeId": (int, None)
-        },
-        location="json"
-    )
+    @validate_args({"challengeId": (int, None)}, location="json")
     def delete(json_args):
         """
         Delete instance of the challengeId provided

--- a/api/instance.py
+++ b/api/instance.py
@@ -3,6 +3,7 @@ This module describes the UserInstance API endpoint of the plugin:
 Route: /api/v1/plugins/ctfd-chall-manager/instance.
 """
 
+from CTFd.api.v1.helpers.request import validate_args
 from CTFd.plugins.ctfd_chall_manager.models import DynamicIaCChallenge
 from CTFd.plugins.ctfd_chall_manager.utils.chall_manager_error import (
     ChallManagerException,
@@ -45,12 +46,18 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    def get():
+    @validate_args(
+        {
+            "challengeId": (int, None)
+        },
+        location="query"
+    )
+    def get(query_args):
         """
         Retrieve instance informations of challengeId provided on Chall-Manager.
         """
         # mandatory
-        challenge_id = request.args.get("challengeId")
+        challenge_id = query_args.pop("challengeId", None)
 
         # check userMode of CTFd
         user = current_user.get_current_user()
@@ -100,13 +107,20 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    def post():  # pylint: disable=too-many-return-statements,too-many-branches
+    @validate_args(
+        {
+            "challengeId": (int, None)
+        },
+        location="json"
+    )
+    def post(json_args):  # pylint: disable=too-many-return-statements,too-many-branches
         """
         Create an instance of challengeId provided on Chall-Manager.
         This method requires user to be authenticated and has suffisant mana to perform creation.
         """
-        data = request.get_json()
-        challenge_id = data.get("challengeId")
+        challenge_id = json_args.pop("challengeId", None)
+        if challenge_id is None:
+            abort(400, "missing challenge_id")
 
         user = current_user.get_current_user()
         user_id = int(user.id)
@@ -172,14 +186,20 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    def patch():  # pylint: disable=too-many-return-statements
+    @validate_args(
+        {
+            "challengeId": (int, None)
+        },
+        location="json"
+    )
+    def patch(json_args):  # pylint: disable=too-many-return-statements
         """
         Renew instance on Chall-Manager.
         If the challengeId provided
         """
-        # mandatory
-        data = request.get_json()
-        challenge_id = data.get("challengeId")
+        challenge_id = json_args.pop("challengeId", None)
+        if challenge_id is None:
+            abort(400, "missing challenge_id")
 
         user = current_user.get_current_user()
         user_id = int(user.id)
@@ -225,12 +245,19 @@ class UserInstance(Resource):
     @staticmethod
     @authed_only
     @challenge_visible
-    def delete():
+    @validate_args(
+        {
+            "challengeId": (int, None)
+        },
+        location="json"
+    )
+    def delete(json_args):
         """
         Delete instance of the challengeId provided
         """
-        data = request.get_json()
-        challenge_id = data.get("challengeId")
+        challenge_id = json_args.pop("challengeId", None)
+        if challenge_id is None:
+            abort(400, "missing challenge_id")
 
         user = current_user.get_current_user()
         user_id = int(user.id)

--- a/hack/docker-compose-minimal.yml
+++ b/hack/docker-compose-minimal.yml
@@ -9,14 +9,14 @@ services:
       - chall-manager
 
   chall-manager:
-    image: ctferio/chall-manager:v0.6.5@sha256:f30d8d4c0b2fee99ffd8b29b1821d014c0c2ef1b134f87f16ade4e21b3f72f16 # TODO configure dependabot to monitor this tag
+    image: ctferio/chall-manager:v0.6.6@sha256:34b5ca4b9e02db171cd58f148f927c0955c106427e97e4525e0376c2512c3959 # TODO configure dependabot to monitor this tag
     environment:
       OCI_INSECURE: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # Used by the example scenario, remove if unecessary
 
   chall-manager-janitor:
-    image: ctferio/chall-manager-janitor:v0.6.5@sha256:722958a53a57a2fe4697a0f7477050e6200c0503da708c2c6eeb5d06b444ebba # TODO configure dependabot to monitor this tag
+    image: ctferio/chall-manager-janitor:v0.6.6@sha256:69ee55e6ad10f25b6c454c70b4de49350c82e5dde9c681a3e1c3ac623a6e0970 # TODO configure dependabot to monitor this tag
     environment:
       URL: chall-manager:8080
       TICKER: 1m

--- a/hack/docker-compose-redis.yml
+++ b/hack/docker-compose-redis.yml
@@ -78,7 +78,7 @@ services:
       - "traefik.http.services.web.loadbalancer.server.port=8000"
 
   chall-manager:
-    image: ctferio/chall-manager:v0.6.5@sha256:f30d8d4c0b2fee99ffd8b29b1821d014c0c2ef1b134f87f16ade4e21b3f72f16
+    image: ctferio/chall-manager:v0.6.6@sha256:34b5ca4b9e02db171cd58f148f927c0955c106427e97e4525e0376c2512c3959
     container_name: chall-manager
     pull_policy: always
     ports:
@@ -95,7 +95,7 @@ services:
       - "traefik.enable=false"
 
   chall-manager-janitor:
-    image: ctferio/chall-manager-janitor:v0.6.5@sha256:722958a53a57a2fe4697a0f7477050e6200c0503da708c2c6eeb5d06b444ebba
+    image: ctferio/chall-manager-janitor:v0.6.6@sha256:69ee55e6ad10f25b6c454c70b4de49350c82e5dde9c681a3e1c3ac623a6e0970
     container_name: chall-manager-janitor
     pull_policy: always
     environment:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       timeout: 10s
 
   chall-manager:
-    image: ctferio/chall-manager:v0.6.5@sha256:f30d8d4c0b2fee99ffd8b29b1821d014c0c2ef1b134f87f16ade4e21b3f72f16
+    image: ctferio/chall-manager:v0.6.6@sha256:34b5ca4b9e02db171cd58f148f927c0955c106427e97e4525e0376c2512c3959
     container_name: chall-manager
     pull_policy: always
     ports:
@@ -38,7 +38,7 @@ services:
       - testing
 
   chall-manager-janitor:
-    image: ctferio/chall-manager-janitor:v0.6.5@sha256:722958a53a57a2fe4697a0f7477050e6200c0503da708c2c6eeb5d06b444ebba
+    image: ctferio/chall-manager-janitor:v0.6.6@sha256:69ee55e6ad10f25b6c454c70b4de49350c82e5dde9c681a3e1c3ac623a6e0970
     container_name: chall-manager-janitor
     pull_policy: always
     environment:

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -13,58 +13,9 @@ from CTFd.plugins.ctfd_chall_manager.utils.challenge_store import query_challeng
 from CTFd.plugins.ctfd_chall_manager.utils.instance_manager import query_instance
 from CTFd.plugins.ctfd_chall_manager.utils.logger import configure_logger
 from CTFd.utils import get_config
-from CTFd.utils import user as current_user
-from CTFd.utils.config import is_teams_mode
-from flask import request
 from sqlalchemy import func
 
 logger = configure_logger(__name__)
-
-
-def retrieve_all_ids(admin=False) -> dict[str, int] | ValueError:
-    """
-    This function return all ids for AdminInstance calls.
-
-    return: dict of {"user_id", "team_id", "source_id", "challenge_id"}
-    """
-    team_id = 0
-    admin_id = 0
-
-    user = current_user.get_current_user()
-    user_id = int(user.id)
-
-    if admin:
-        admin_id = user_id
-
-    # If GET
-    challenge_id = request.args.get("challengeId")
-    source_id = request.args.get("sourceId")
-
-    if challenge_id is None or source_id is None:  # If POST/PATCH/DELETE
-        data = request.get_json()
-        challenge_id = data.get("challengeId")
-        source_id = data.get("sourceId")
-
-    if challenge_id is None or source_id is None:
-        raise ValueError("missing challengeId or sourceId")
-
-    challenge_id = int(challenge_id)
-    source_id = int(source_id)
-
-    if not admin:
-        source_id = user_id
-        if is_teams_mode():
-            team_id = user.team_id
-            if team_id is not None:
-                source_id = int(team_id)
-
-    return {
-        "admin_id": admin_id,
-        "user_id": user_id,
-        "team_id": team_id,
-        "source_id": source_id,
-        "challenge_id": challenge_id,
-    }
 
 
 def calculate_mana_used(source_id: int) -> int | ChallManagerException:


### PR DESCRIPTION
This PR : 
- upgrade chall-manager[-janitor] deps to 0.6.6
- add `validate_args` decorator from CTFd to facilitate the handling of parameters.

Note : there is no feature or bugfix in this PR so we don't need to make a tag. 